### PR TITLE
There is no benefit in using bytes32[1] over bytes32

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,7 @@ const parseStruct = function(struct) {
     name: calculateName(struct.name),
     variables: variables,
     slots: slots,
+    slotsArray: slots.length > 1,
     slotsLength: _.last(variables).slot + 1
   };
 };

--- a/src/templates/contracts/StructLite.mustache
+++ b/src/templates/contracts/StructLite.mustache
@@ -69,7 +69,7 @@ import "./{{ name.Plural }}Coder.sol";
 library {{ name.Plural }} {
     // This variable will contain all of the data.
     struct {{ name.UpperCamelCase }} {
-        bytes32[{{ slotsLength }}] data;
+        bytes32{{#if slotsArray}}[{{ slotsLength }}]{{/if}} data;
     }
 
     ////

--- a/src/templates/contracts/StructLiteCoder.mustache
+++ b/src/templates/contracts/StructLiteCoder.mustache
@@ -24,11 +24,11 @@ library {{ name.Plural }}Coder {
     {{#unless @first}}
 
     {{/unless}}
-    function decode{{ ../name.UpperCamelCase }}{{ name.UpperCamelCase }}(bytes32[{{ ../slotsLength }}] _{{ ../name.lowerCamelCase }}) public pure returns({{ type }}) {
+    function decode{{ ../name.UpperCamelCase }}{{ name.UpperCamelCase }}(bytes32{{#if ../slotsArray}}[{{ ../slotsLength }}]{{/if}} _{{ ../name.lowerCamelCase }}) public pure returns({{ type }}) {
     {{#if isBool}}
-        return (uint256(_{{ ../name.lowerCamelCase }}[{{ slot }}]) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK) != 0x0;
+        return (uint256(_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK) != 0x0;
         {{else}}
-        return {{type}}((uint256(_{{ ../name.lowerCamelCase }}[{{ slot }}]) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK){{#unless isFirst}} / {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_OFFSET{{/unless}});
+        return {{type}}((uint256(_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK){{#unless isFirst}} / {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_OFFSET{{/unless}});
         {{/if}}
     }
     {{/each}}
@@ -40,18 +40,18 @@ library {{ name.Plural }}Coder {
     {{#unless @first}}
 
     {{/unless}}
-    function encode{{ ../name.UpperCamelCase }}{{ name.UpperCamelCase }}(bytes32[{{ ../slotsLength }}] _{{ ../name.lowerCamelCase }}, {{ type }} _{{ name.lowerCamelCase }}) public pure returns(bytes32[{{ ../slotsLength }}]) {
+    function encode{{ ../name.UpperCamelCase }}{{ name.UpperCamelCase }}(bytes32{{#if ../slotsArray}}[{{ ../slotsLength }}]{{/if}} _{{ ../name.lowerCamelCase }}, {{ type }} _{{ name.lowerCamelCase }}) public pure returns(bytes32{{#if ../slotsArray}}[{{ ../slotsLength }}]{{/if}}) {
         {{#if isBool}}
         if (_{{ name.lowerCamelCase }}) {
-            _{{ ../name.lowerCamelCase }}[{{ slot }}] = bytes32(
-                (uint256(_{{ ../name.lowerCamelCase }}[{{ slot }}]) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_NEGATIVE_MASK) | {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK
+            _{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}} = bytes32(
+                (uint256(_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_NEGATIVE_MASK) | {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK
             );
         } else {
-            _{{ ../name.lowerCamelCase }}[{{ slot }}] = bytes32(uint256(_{{ ../name.lowerCamelCase }}[{{ slot }}]) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_NEGATIVE_MASK);
+            _{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}} = bytes32(uint256(_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_NEGATIVE_MASK);
         }
         {{else}}
-        _{{ ../name.lowerCamelCase }}[{{ slot }}] = bytes32(
-            (uint256(_{{ ../name.lowerCamelCase }}[{{ slot }}]) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_NEGATIVE_MASK) |
+        _{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}} = bytes32(
+            (uint256(_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_NEGATIVE_MASK) |
             ((uint256(_{{ name.lowerCamelCase }}){{#unless isFirst}} * {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_OFFSET{{/unless}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK)
         );
         {{/if}}
@@ -63,16 +63,14 @@ library {{ name.Plural }}Coder {
         {{#each variables}}
         {{ type }} _{{ name.lowerCamelCase }}{{#unless @last}},{{/unless}}
         {{/each}}
-    ) public pure returns(bytes32[{{ slotsLength }}]) {
-        bytes32[{{ slotsLength }}] memory _{{ name.lowerCamelCase }};
+    ) public pure returns(bytes32{{#if slotsArray}}[{{ slotsLength }}]{{/if}} _{{ name.lowerCamelCase }}) {
         {{#each slots}}
-        _{{ ../name.lowerCamelCase }}[{{ @index }}] = encode{{ ../name.UpperCamelCase }}DataSlot{{ @index }}(
+        _{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ @index }}]{{/if}} = encode{{ ../name.UpperCamelCase }}DataSlot{{ @index }}(
             {{#each this}}
             _{{ name.lowerCamelCase }}{{#unless @last}},{{/unless}}
             {{/each}}
         );
         {{/each}}
-        return _{{ name.lowerCamelCase }};
     }
 
     {{#each slots}}

--- a/src/templates/test/function_parameters_scenario_specs.mustache
+++ b/src/templates/test/function_parameters_scenario_specs.mustache
@@ -73,7 +73,7 @@ contract("{{ name.Plural }}FunctionParametersScenario", () => {
       {{/each}}
     ] = await {{ name.plural }}FunctionParametersScenario.unknownLengthStructArray.call(
       {{#each slots}}
-      [data[{{@index}}]]{{#unless @last}},{{/unless}}
+      [data{{#if ../slotsArray}}[{{@index}}]{{/if}}]{{#unless @last}},{{/unless}}
       {{/each}}
     );
 

--- a/src/templates/test/scenarios/FunctionParametersScenario.mustache
+++ b/src/templates/test/scenarios/FunctionParametersScenario.mustache
@@ -4,24 +4,24 @@ import "../../contracts/{{ name.Plural }}Coder.sol";
 
 
 contract {{ name.Plural }}FunctionParametersScenario {
-    function singleStruct(bytes32[{{ slotsLength }}] _{{ name.lowerCamelCase }}Data) public pure returns(
+    function singleStruct(bytes32{{#if slotsArray}}[{{ slotsLength }}]{{/if}} _{{ name.lowerCamelCase }}Data) public pure returns(
         {{#each variables}}
         {{ type }} {{ name.lowerCamelCase }}{{#unless @last}},{{/unless}}
         {{/each}}
     ) {
-        bytes32[{{ slotsLength }}] memory _{{ name.lowerCamelCase }};
+        bytes32{{#if slotsArray}}[{{ slotsLength }}] memory{{/if}} _{{ name.lowerCamelCase }};
         _{{ name.lowerCamelCase }} = _{{ name.lowerCamelCase }}Data;
         {{#each variables}}
         {{ name.lowerCamelCase }} = {{ ../name.Plural }}Coder.decode{{ ../name.UpperCamelCase }}{{ name.UpperCamelCase }}(_{{ ../name.lowerCamelCase }});
         {{/each}}
     }
 
-    function knownLengthStructArray(bytes32[{{ slotsLength }}][10] _{{ name.lowerCamelCase }}Data) public pure returns(
+    function knownLengthStructArray(bytes32{{#if slotsArray}}[{{ slotsLength }}]{{/if}}[10] _{{ name.lowerCamelCase }}Data) public pure returns(
         {{#each variables}}
         {{ type }} {{ name.lowerCamelCase }}{{#unless @last}},{{/unless}}
         {{/each}}
     ) {
-        bytes32[{{ slotsLength }}][10] memory _{{ name.plural }};
+        bytes32{{#if slotsArray}}[{{ slotsLength }}]{{/if}}[10] memory _{{ name.plural }};
         for (uint i = 0; i < _{{ name.lowerCamelCase }}Data.length; i++) {
             _{{ name.plural }}[i] = _{{ name.lowerCamelCase }}Data[i];
         }
@@ -39,11 +39,11 @@ contract {{ name.Plural }}FunctionParametersScenario {
         {{ type }} {{ name.lowerCamelCase }}{{#unless @last}},{{/unless}}
         {{/each}}
     ) {
-        bytes32[{{ slotsLength }}][] storage _{{ name.plural }};
+        bytes32{{#if slotsArray}}[{{ slotsLength }}]{{/if}}[] storage _{{ name.plural }};
         _{{ name.plural }}.length = _{{ name.lowerCamelCase }}DataSlot0.length;
         for (uint i = 0; i < _{{ name.lowerCamelCase }}DataSlot0.length; i++) {
             {{#each slots}}
-            _{{ ../name.plural }}[i][{{ @index }}] = _{{ ../name.lowerCamelCase }}DataSlot{{ @index }}[i];
+            _{{ ../name.plural }}[i]{{#if ../slotsArray}}[{{ @index }}]{{/if}} = _{{ ../name.lowerCamelCase }}DataSlot{{ @index }}[i];
             {{/each}}
         }
         {{#each variables}}


### PR DESCRIPTION
When the length of the slots is 1