### PR TITLE
Avoiding Unnecessary Castings by storing data as uint256

### DIFF
--- a/src/templates/contracts/StructLite.mustache
+++ b/src/templates/contracts/StructLite.mustache
@@ -69,7 +69,7 @@ import "./{{ name.Plural }}Coder.sol";
 library {{ name.Plural }} {
     // This variable will contain all of the data.
     struct {{ name.UpperCamelCase }} {
-        bytes32{{#if slotsArray}}[{{ slotsLength }}]{{/if}} data;
+        uint256{{#if slotsArray}}[{{ slotsLength }}]{{/if}} data;
     }
 
     ////

--- a/src/templates/contracts/StructLiteCoder.mustache
+++ b/src/templates/contracts/StructLiteCoder.mustache
@@ -24,11 +24,11 @@ pragma solidity 0.4.24;
     {{#unless @first}}
 
     {{/unless}}
-    function decode{{ ../name.UpperCamelCase }}{{ name.UpperCamelCase }}(bytes32{{#if ../slotsArray}}[{{ ../slotsLength }}]{{/if}} _{{ ../name.lowerCamelCase }}) public pure returns({{ type }}) {
-    {{#if isBool}}
-        return (uint256(_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK) != 0x0;
+    function decode{{ ../name.UpperCamelCase }}{{ name.UpperCamelCase }}(uint256{{#if ../slotsArray}}[{{ ../slotsLength }}]{{/if}} _{{ ../name.lowerCamelCase }}) public pure returns({{ type }}) {
+        {{#if isBool}}
+        return (_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}} & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK) != 0x0;
         {{else}}
-        return {{type}}((uint256(_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK){{#unless isFirst}} / {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_OFFSET{{/unless}});
+        return {{type}}((_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}} & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK){{#unless isFirst}} / {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_OFFSET{{/unless}});
         {{/if}}
     }
     {{/each}}
@@ -40,20 +40,18 @@ pragma solidity 0.4.24;
     {{#unless @first}}
 
     {{/unless}}
-    function encode{{ ../name.UpperCamelCase }}{{ name.UpperCamelCase }}(bytes32{{#if ../slotsArray}}[{{ ../slotsLength }}]{{/if}} _{{ ../name.lowerCamelCase }}, {{ type }} _{{ name.lowerCamelCase }}) public pure returns(bytes32{{#if ../slotsArray}}[{{ ../slotsLength }}]{{/if}}) {
+    function encode{{ ../name.UpperCamelCase }}{{ name.UpperCamelCase }}(uint256{{#if ../slotsArray}}[{{ ../slotsLength }}]{{/if}} _{{ ../name.lowerCamelCase }}, {{ type }} _{{ name.lowerCamelCase }}) public pure returns(uint256{{#if ../slotsArray}}[{{ ../slotsLength }}]{{/if}}) {
         {{#if isBool}}
         if (_{{ name.lowerCamelCase }}) {
-            _{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}} = bytes32(
-                (uint256(_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_NEGATIVE_MASK) | {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK
-            );
+            _{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}} = {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK |
+                (uint256(_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_NEGATIVE_MASK);
         } else {
-            _{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}} = bytes32(uint256(_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_NEGATIVE_MASK);
+            _{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}} = uint256(_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_NEGATIVE_MASK;
         }
         {{else}}
-        _{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}} = bytes32(
+        _{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}} =
             (uint256(_{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ slot }}]{{/if}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_NEGATIVE_MASK) |
-            ((uint256(_{{ name.lowerCamelCase }}){{#unless isFirst}} * {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_OFFSET{{/unless}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK)
-        );
+            ((uint256(_{{ name.lowerCamelCase }}){{#unless isFirst}} * {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_OFFSET{{/unless}}) & {{ ../name.CONSTANT }}_{{ name.CONSTANT }}_MASK);
         {{/if}}
         return _{{ ../name.lowerCamelCase }};
     }
@@ -63,7 +61,7 @@ pragma solidity 0.4.24;
         {{#each variables}}
         {{ type }} _{{ name.lowerCamelCase }}{{#unless @last}},{{/unless}}
         {{/each}}
-    ) public pure returns(bytes32{{#if slotsArray}}[{{ slotsLength }}]{{/if}} _{{ name.lowerCamelCase }}) {
+    ) public pure returns(uint256{{#if slotsArray}}[{{ slotsLength }}]{{/if}} _{{ name.lowerCamelCase }}) {
         {{#each slots}}
         _{{ ../name.lowerCamelCase }}{{#if ../slotsArray}}[{{ @index }}]{{/if}} = encode{{ ../name.UpperCamelCase }}DataSlot{{ @index }}(
             {{#each this}}
@@ -81,7 +79,7 @@ pragma solidity 0.4.24;
         {{#each this}}
         {{ type }} _{{ name.lowerCamelCase }}{{#unless @last}},{{/unless}}
         {{/each}}
-    ) internal pure returns(bytes32) {
+    ) internal pure returns(uint256) {
         {{#each this}}
         {{#if isBool}}
         uint256 standard{{ name.UpperCamelCase }} = (_{{ name.lowerCamelCase }} ? {{ ../../name.CONSTANT }}_{{ name.CONSTANT }}_MASK : {{ ../../name.CONSTANT }}_{{ name.CONSTANT }}_NEGATIVE_MASK);
@@ -89,7 +87,7 @@ pragma solidity 0.4.24;
         uint256 standard{{ name.UpperCamelCase }} = uint256(_{{ name.lowerCamelCase }});
         {{/if}}
         {{/each}}
-        return bytes32(
+        return (
             {{#each this}}
             ((standard{{ name.UpperCamelCase }}{{#unless isBool}}{{#unless isFirst}} * {{ ../../name.CONSTANT }}_{{ name.CONSTANT }}_OFFSET{{/unless}}{{/unless}}) & {{ ../../name.CONSTANT }}_{{ name.CONSTANT }}_MASK){{#unless @last}} |{{/unless}}
             {{/each}}

--- a/src/templates/test/scenarios/FunctionParametersScenario.mustache
+++ b/src/templates/test/scenarios/FunctionParametersScenario.mustache
@@ -8,7 +8,7 @@ contract {{ name.Plural }}FunctionParametersScenario is {{ name.Plural }}CoderCo
     {{ type }}[] private unknownLenght{{ name.UpperCamelCase }};
     {{/each}}
 
-    function singleStruct(bytes32{{#if slotsArray}}[{{ slotsLength }}]{{/if}} _{{ name.lowerCamelCase }}Data) public pure returns(
+    function singleStruct(uint256{{#if slotsArray}}[{{ slotsLength }}]{{/if}} _{{ name.lowerCamelCase }}Data) public pure returns(
         {{#each variables}}
         {{ type }}{{#unless @last}},{{/unless}}
         {{/each}}
@@ -23,7 +23,7 @@ contract {{ name.Plural }}FunctionParametersScenario is {{ name.Plural }}CoderCo
         );
     }
 
-    function knownLengthStructArray(bytes32{{#if slotsArray}}[{{ slotsLength }}]{{/if}}[10] _{{ name.lowerCamelCase }}Data) public pure returns(
+    function knownLengthStructArray(uint256{{#if slotsArray}}[{{ slotsLength }}]{{/if}}[10] _{{ name.lowerCamelCase }}Data) public pure returns(
         {{#each variables}}
         {{ type }}{{#unless @last}},{{/unless}}
         {{/each}}
@@ -47,14 +47,14 @@ contract {{ name.Plural }}FunctionParametersScenario is {{ name.Plural }}CoderCo
 
     function unknownLengthStructArray(
         {{#each slots}}
-        bytes32[] _{{ ../name.lowerCamelCase }}DataSlot{{ @index }}{{#unless @last}},{{/unless}}
+        uint256[] _{{ ../name.lowerCamelCase }}DataSlot{{ @index }}{{#unless @last}},{{/unless}}
         {{/each}}
     ) public returns(
         {{#each variables}}
         {{ type }}{{#unless @last}},{{/unless}}
         {{/each}}
     ) {
-        bytes32{{#if slotsArray}}[{{ slotsLength }}] memory{{/if}} _{{ name.lowerCamelCase }};
+        uint256{{#if slotsArray}}[{{ slotsLength }}] memory{{/if}} _{{ name.lowerCamelCase }};
 
         {{#each variables}}
         unknownLenght{{ name.UpperCamelCase }}.length = _{{ ../name.lowerCamelCase }}DataSlot0.length;


### PR DESCRIPTION
after some tests of possible optimizations.

byte shifting using `<<` and `>>` is worse than multiplication and division.

so to avoid castings the main type will be `uint256`